### PR TITLE
Add game controller support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ wireless-hid shows the battery of the wireless keyboards and mice both in percen
 ## Manual installation
 
  1. `git clone https://github.com/vchlum/wireless-hid.git`
- 1. `cd hue-lights`
+ 1. `cd wireless-hid`
  1. `./release.sh`
  1. `gnome-extensions install wireless-hid@chlumskyvaclav.gmail.com.zip`
  1. Log out & Log in

--- a/wirelesshid.js
+++ b/wirelesshid.js
@@ -161,10 +161,10 @@ var HID =  GObject.registerClass({
 
         if (this.kind === UPower.DeviceKind.KEYBOARD) {
             iconName = 'input-keyboard';
-        }
-
-        if (this.kind === UPower.DeviceKind.MOUSE) {
+        } else if (this.kind === UPower.DeviceKind.MOUSE) {
             iconName = 'input-mouse';
+        } else if (this.kind === UPower.DeviceKind.GAMING_INPUT) {
+            iconName = 'input-gaming';
         }
 
         this.icon = new St.Icon({
@@ -321,7 +321,8 @@ var WirelessHID = GObject.registerClass({
          */
         for (let i = 0; i < devices.length; i++) {
 			if (devices[i].kind === UPower.DeviceKind.KEYBOARD ||
-                devices[i].kind === UPower.DeviceKind.MOUSE) {
+                devices[i].kind === UPower.DeviceKind.MOUSE ||
+                devices[i].kind === UPower.DeviceKind.GAMING_INPUT) {
 
                 let exist = false; 
                 for (let j in this._devices) {


### PR DESCRIPTION
Hi,

I noticed that my PS controller wasn't being shown in the icons, I added the GAMING_INPUT class so that game controllers can also be shown. I have tested it on my machine and it is included now.

I also fixed the cd directory on the README file