### PR TITLE
Don't add devices with unknown device state

### DIFF
--- a/wirelesshid.js
+++ b/wirelesshid.js
@@ -310,6 +310,7 @@ var WirelessHID = GObject.registerClass({
          * discover new devices
          */
         for (let i = 0; i < devices.length; i++) {
+            if (devices[i].state === UPower.DeviceState.UNKNOWN) continue;
             if (devices[i].kind != UPower.DeviceKind.KEYBOARD &&
                 devices[i].kind != UPower.DeviceKind.MOUSE &&
                 devices[i].kind != UPower.DeviceKind.GAMING_INPUT) continue;


### PR DESCRIPTION
This patch series includes 2 style commits to fix multiple left over tabs, please look at the commits individually since the actual change of code is only one line.

My laptop built-in normal keyboard shows in this widget while it has no battery.

It shows like this on upower:

```
Device: /org/freedesktop/UPower/devices/keyboard_hid_0018o04F3o2AD1x0004_battery
  native-path:          hid-0018:04F3:2AD1.0004-battery
  model:                ELAN2513:00 04F3:2AD1
  power supply:         no
  updated:              So 24 Oct 2021 14:44:20 CEST (62 seconds ago)
  has history:          yes
  has statistics:       yes
  keyboard
    present:             yes
    rechargeable:        yes
    state:               unknown
    warning-level:       none
    percentage:          0%
    icon-name:          'battery-missing-symbolic'
```
For this reason this pull request filters out devices with "state === UPower.DeviceState.UNKNOWN".