### PR TITLE
Workaround for mouse recognized as keyboard.

### DIFF
--- a/wirelesshid.js
+++ b/wirelesshid.js
@@ -175,7 +175,7 @@ var HID = GObject.registerClass({
             default: iconName = 'battery';
         }
 
-        // Workaround for bug
+        // Workaround for mouse recognized as keyboard
         if (this.model.includes('Mouse'))
             iconName = 'input-mouse';
 

--- a/wirelesshid.js
+++ b/wirelesshid.js
@@ -175,6 +175,10 @@ var HID = GObject.registerClass({
             default: iconName = 'battery';
         }
 
+        // Workaround for bug
+        if (this.model.includes('Mouse'))
+            iconName = 'input-mouse';
+
         this.icon = new St.Icon({
             icon_name: iconName+'-symbolic',
             style_class: 'system-status-icon'


### PR DESCRIPTION
I want to propose this workaround for people like me who have a keyboard and a mouse paired with the same receiver, and the mouse is recognized as a keyboard. Until the problem is solved in upower. Cases also reported in the issue #10.