### PR TITLE
Skip the device if the battery is missing

### DIFF
--- a/wirelesshid.js
+++ b/wirelesshid.js
@@ -344,6 +344,10 @@ var WirelessHID = GObject.registerClass({
                 continue;
             }
 
+            if (devices[i].state === 0 && devices[i].iconName === "battery-missing-symbolic") {
+                continue;
+            }
+
             let exist = false;
             for (let j in this._devices) {
                 if (this._devices[j].nativePath === devices[i].native_path) {


### PR DESCRIPTION
Some devices (such as the wireless pen on the Lenovo Yoga 7 Gen 7) report a battery even if it's missing.
This checks both state and icon name, as some devices may not report the battery state, while still having a battery present. If you want, I can add that line in as a comment.

Let me know if you want any changes :)