### PR TITLE
Add setting to hide devices that haven't updated after a timeout

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -34,10 +34,14 @@ var PrefsPages = class PrefsPages {
       'hide-elan-switch': {
         'settingKey': 'hide-elan',
         'bindProperty': 'active'
+      },
+      'device-timeout-adjustment': {
+        'settingKey': 'device-update-timeout',
+        'bindProperty': 'value'
       }
     }
 
-    //Loop through settings toggles and dropdowns and bind together
+    //Loop through settings toggles and inputs and bind together
     Object.keys(this.settingElements).forEach((element) => {
       this._settings.bind(
         this.settingElements[element].settingKey, //GSettings key to bind to

--- a/schemas/org.gnome.shell.extensions.wireless-hid.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.wireless-hid.gschema.xml
@@ -9,7 +9,12 @@
     <key name="hide-elan" type="b">
       <default>false</default>
       <summary>Hide ELAN devices</summary>
-      <description>Some ELAN devices do not show a battery state. This option allows hiding such devices.</description>
+      <description>Some ELAN devices do not show a battery state, this setting allows hiding such devices</description>
+    </key>
+    <key name="device-update-timeout" type="i">
+      <default>0</default>
+      <summary>Hide old devices after a timeout</summary>
+      <description>Some devices don't disconnect, this setting allows setting a timeout to hide them if they haven't updated recently</description>
     </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.wireless-hid.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.wireless-hid.gschema.xml
@@ -13,7 +13,7 @@
     </key>
     <key name="device-update-timeout" type="i">
       <default>0</default>
-      <summary>Hide old devices after a timeout</summary>
+      <summary>Hide old devices after a timeout (seconds)</summary>
       <description>Some devices don't disconnect, this setting allows setting a timeout to hide them if they haven't updated recently</description>
     </key>
   </schema>

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -120,6 +120,51 @@
                     </property>
                   </object>
                 </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="focusable">1</property>
+                    <property name="activatable">0</property>
+                    <property name="selectable">0</property>
+                    <property name="child">
+                      <object class="GtkSeparator"/>
+                    </property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="focusable">1</property>
+                    <property name="tooltip-text" translatable="1">Some devices don&apos;t disconnect, this setting allows setting a timeout to hide them if they haven&apos;t updated recently</property>
+                    <property name="child">
+                      <object class="GtkBox">
+                        <property name="margin-top">12</property>
+                        <property name="margin-bottom">12</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="spacing">32</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="hexpand">1</property>
+                                <property name="valign">center</property>
+                                <property name="margin-start">10</property>
+                                <property name="label" translatable="1">Hide old devices after a timeout</property>
+                                <property name="xalign">0</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkSwitch" id="hide-elan-switch1">
+                                <property name="focusable">1</property>
+                                <property name="valign">center</property>
+                                <property name="margin-end">10</property>
+                                <property name="active">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
+                </child>
                 <style>
                   <class name="frame"/>
                 </style>

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -79,6 +79,16 @@
                   <object class="GtkListBoxRow">
                     <property name="focusable">1</property>
                     <property name="tooltip-text" translatable="1" comments="This is a tooltip">Some ELAN devices do not show a battery state. This option allows hiding such devices.</property>
+                    <property name="activatable">0</property>
+                    <property name="selectable">0</property>
+                    <property name="child">
+                      <object class="GtkSeparator"/>
+                    </property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="focusable">1</property>
                     <property name="child">
                       <object class="GtkBox">
                         <property name="margin-top">12</property>

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -153,13 +153,14 @@
                                 <property name="hexpand">1</property>
                                 <property name="valign">center</property>
                                 <property name="margin-start">10</property>
-                                <property name="label" translatable="1">Hide old devices after a timeout</property>
+                                <property name="label" translatable="1">Hide old devices after a timeout (seconds)</property>
                                 <property name="xalign">0</property>
                               </object>
                             </child>
                             <child>
                               <object class="GtkSpinButton" id="device-update-timeout-entry">
                                 <property name="focusable">1</property>
+                                <property name="tooltip-text" translatable="1">Set to 0 to disable</property>
                                 <property name="margin-end">10</property>
                                 <property name="adjustment">device-timeout-adjustment</property>
                                 <property name="numeric">1</property>

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface domain="">
   <requires lib="gtk" version="4.0"/>
+  <object class="GtkAdjustment" id="device-timeout-adjustment">
+    <property name="upper">99999</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkBox" id="main-prefs">
     <property name="margin-top">12</property>
     <property name="margin-bottom">10</property>
@@ -153,11 +158,12 @@
                               </object>
                             </child>
                             <child>
-                              <object class="GtkSwitch" id="hide-elan-switch1">
+                              <object class="GtkSpinButton" id="device-update-timeout-entry">
                                 <property name="focusable">1</property>
-                                <property name="valign">center</property>
                                 <property name="margin-end">10</property>
-                                <property name="active">1</property>
+                                <property name="adjustment">device-timeout-adjustment</property>
+                                <property name="numeric">1</property>
+                                <property name="update-policy">if-valid</property>
                               </object>
                             </child>
                           </object>

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -89,6 +89,7 @@
                 <child>
                   <object class="GtkListBoxRow">
                     <property name="focusable">1</property>
+                    <property name="tooltip-text" translatable="1">Some ELAN devices do not show a battery state, this setting allows hiding such devices</property>
                     <property name="child">
                       <object class="GtkBox">
                         <property name="margin-top">12</property>

--- a/ui/prefs.ui
+++ b/ui/prefs.ui
@@ -242,7 +242,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="valign">center</property>
                                 <property name="margin-start">10</property>
-                                <property name="label" translatable="yes">Hide old devices after a timeout</property>
+                                <property name="label" translatable="yes">Hide old devices after a timeout (seconds)</property>
                                 <property name="xalign">0</property>
                               </object>
                               <packing>
@@ -255,6 +255,7 @@
                               <object class="GtkSpinButton" id="device-update-timeout-entry">
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
+                                <property name="tooltip-text" translatable="yes">Set to 0 to disable</property>
                                 <property name="margin-end">10</property>
                                 <property name="adjustment">device-timeout-adjustment</property>
                                 <property name="numeric">True</property>

--- a/ui/prefs.ui
+++ b/ui/prefs.ui
@@ -2,6 +2,11 @@
 <!-- Generated with glade 3.40.0 -->
 <interface domain="">
   <requires lib="gtk+" version="3.16"/>
+  <object class="GtkAdjustment" id="device-timeout-adjustment">
+    <property name="upper">99999</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkBox" id="main-prefs">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -247,12 +252,13 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkSwitch" id="hide-elan-switch1">
+                              <object class="GtkSpinButton" id="device-update-timeout-entry">
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
-                                <property name="valign">center</property>
                                 <property name="margin-end">10</property>
-                                <property name="active">True</property>
+                                <property name="adjustment">device-timeout-adjustment</property>
+                                <property name="numeric">True</property>
+                                <property name="update-policy">if-valid</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>

--- a/ui/prefs.ui
+++ b/ui/prefs.ui
@@ -199,6 +199,77 @@
                     </child>
                   </object>
                 </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="activatable">False</property>
+                    <property name="selectable">False</property>
+                    <child>
+                      <object class="GtkSeparator">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="tooltip-text" translatable="yes">Some devices don't disconnect, this setting allows setting a timeout to hide them if they haven't updated recently</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-top">12</property>
+                        <property name="margin-bottom">12</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="spacing">32</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="valign">center</property>
+                                <property name="margin-start">10</property>
+                                <property name="label" translatable="yes">Hide old devices after a timeout</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSwitch" id="hide-elan-switch1">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="valign">center</property>
+                                <property name="margin-end">10</property>
+                                <property name="active">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
                 <style>
                   <class name="frame"/>
                 </style>

--- a/ui/prefs.ui
+++ b/ui/prefs.ui
@@ -133,6 +133,20 @@
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="tooltip-text" translatable="yes" comments="This is a tooltip">Some ELAN devices do not show a battery state. This option allows hiding such devices.</property>
+                    <property name="activatable">False</property>
+                    <property name="selectable">False</property>
+                    <child>
+                      <object class="GtkSeparator">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>

--- a/ui/prefs.ui
+++ b/ui/prefs.ui
@@ -147,6 +147,7 @@
                   <object class="GtkListBoxRow">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
+                    <property name="tooltip-text" translatable="yes">Some ELAN devices do not show a battery state, this setting allows hiding such devices</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>


### PR DESCRIPTION
Hi again :)

This pull request does a couple things:
 - Adds GTK separators between settings, to make the interface more manageable
 - Adds a tooltip to the "Hide ELAN devices" setting, for consistency with the other 2
 - Adds a new setting to hide devices that haven't updated in a while

Some devices (like drawing pens) don't update their battery until they're brought near the screen, and the digitiser never disconnects. This means that using a drawing pen, then putting it away will cause the battery indicator to be shown until the device driver restarts. To work around this, I added a setting that will hide devices that haven't updated their battery status after a number of settings.

This works by cancelling any running timeout when the extension settings change or the device status updates, then creating a new one. This timeout will hide the device when it reaches 0, if an update hasn't cancelled the timer by this point. If the setting is high enough, the device will always refresh before the timeout is reached, and the device is always visible. If the device is unresponsive, it'll go away until it updates itself.

This is turned off by default, (setting the timeout to 0 will disable the setting, and 0 is the default), because the timeout required depends on the user's hardware.

Let me know if you have any questions or suggestions for the code :)