### PR TITLE
Workaround for controller recognized as keyboard

### DIFF
--- a/wirelesshid.js
+++ b/wirelesshid.js
@@ -234,6 +234,10 @@ var HID = GObject.registerClass({
         if (this.model.includes('Mouse'))
             iconName = 'input-mouse';
 
+        // Workaround for controller recognized as keyboard
+        if (this.model.includes('Controller'))
+            iconName = 'input-gaming';
+
         this.icon = new St.Icon({
             icon_name: iconName+'-symbolic',
             style_class: 'system-status-icon'


### PR DESCRIPTION
Similar like the workaround for mouses but this time for gaming controller.

Using Fedora 37 here with a Dualsense 5 controller, this PR lets it appear as gaming device instead of as a keyboard.

PS: Thanks for your cool extension!