### PR TITLE
Break when devices are found, instead of continuing to search

### DIFF
--- a/wirelesshid.js
+++ b/wirelesshid.js
@@ -454,6 +454,7 @@ var WirelessHID = GObject.registerClass({
             for (let i = 0; i < devices.length; i++) {
                 if (this._devices[j].nativePath === devices[i].native_path) {
                     found = true;
+                    break;
                 }
             }
 
@@ -479,6 +480,7 @@ var WirelessHID = GObject.registerClass({
             for (let j in this._devices) {
                 if (this._devices[j].nativePath === devices[i].native_path) {
                     exist = true;
+                    break;
                 }
             }
 


### PR DESCRIPTION
Small change, just stops it searching longer than it has to. Maybe this will save a few milliseconds on systems with many devices :)