### PR TITLE
Manually destroy devices when extension is disabled

### DIFF
--- a/wirelesshid.js
+++ b/wirelesshid.js
@@ -522,6 +522,10 @@ var WirelessHID = GObject.registerClass({
             this._settings = null;
         }
 
+        for (let deviceId in this._devices) {
+          this._devices[deviceId].destroy();
+        }
+
         super._onDestroy();
     }
 


### PR DESCRIPTION
Devices weren't being destroyed when the extension exists, leaving dangling signals and errors in the system logs.

Closes #24