### PR TITLE
Handle devices with initially blank models

### DIFF
--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -423,7 +423,9 @@ var WirelessHID = GObject.registerClass({
 
             // Add new devices
             for (let i = 0; i < freshDevices.length; i++) {
-                if (freshDevices[i].model.length === 0) {
+                if (freshDevices.model === null) {
+                    continue;
+                } else if (freshDevices[i].model.length === 0) {
                     continue;
                 }
 

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -236,12 +236,14 @@ var HID = GObject.registerClass({
         }
 
         // Workarounds for incorrectly identified devices
-        if (this.device.model.includes('Mouse')) {
-            iconName = 'input-mouse';
-        } else if (this.device.model.includes('Controller')) {
-            iconName = 'input-gaming';
-        } else if (this.device.model.includes('Headset')) {
-            iconName = 'audio-headset';
+        if (this.device.model !== null) {
+            if (this.device.model.includes('Mouse')) {
+                iconName = 'input-mouse';
+            } else if (this.device.model.includes('Controller')) {
+                iconName = 'input-gaming';
+            } else if (this.device.model.includes('Headset')) {
+                iconName = 'audio-headset';
+            }
         }
 
         this.icon = new St.Icon({
@@ -259,8 +261,9 @@ var HID = GObject.registerClass({
 
         this.item.remove_child(this.item.label);
 
+        let model = this.device.model;
         let name = new St.Label({
-            text: `${this.device.model}:`,
+            text: model !== null ? `${model}:` : 'Unknown:',
             y_align: Clutter.ActorAlign.CENTER,
             x_align: Clutter.ActorAlign.START
         });

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -131,8 +131,8 @@ var HID = GObject.registerClass({
           return false;
         }
 
-        //Some devices report 'present' as true, even if no battery is present
-        //To try work-around this, hide devices with an unknown battery state if enabled
+        // Some devices report 'present' as true, even if no battery is present
+        // To try work-around this, hide devices with an unknown battery state if enabled
         if (this._settings.get_boolean('hide-unknown-battery-state')) {
             if (this.device.state === UPowerGlib.DeviceState.UNKNOWN) {
                 return false;
@@ -157,13 +157,13 @@ var HID = GObject.registerClass({
     }
 
     refresh() {
-        //If a timeout is already set, remove it
+        // If a timeout is already set, remove it
         if (this._timeoutUpdateTimeoutId != null) {
             GLib.Source.remove(this._timeoutUpdateTimeoutId);
             this._timeoutUpdateTimeoutId = null;
         }
 
-        //If enabled, create a timer to hide the device if it's not cancelled by an update
+        // If enabled, create a timer to hide the device if it's not cancelled by an update
         let deviceTimeoutLength = this._settings.get_int('device-update-timeout') * 1000;
         if (deviceTimeoutLength != 0) {
             this._timeoutUpdateTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, deviceTimeoutLength, () => {
@@ -381,7 +381,7 @@ var WirelessHID = GObject.registerClass({
                   this.menu.addMenuItem(this._devices[device.native_path].createItem());
                   this._devices[device.native_path].visible = true;
                 }
-                //Uses _update() to avoid cutting timeout short
+                // Uses _update() to avoid cutting timeout short
                 this._devices[device.native_path]._update();
                 this.checkVisibility();
             }
@@ -395,7 +395,7 @@ var WirelessHID = GObject.registerClass({
             }
         );
 
-        //Refresh device with signals now connected
+        // Refresh device with signals now connected
         this._devices[device.native_path].refresh();
 
         this._devices[device.native_path].connect('destroy',

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -120,6 +120,13 @@ var HID = GObject.registerClass({
             shouldBeVisible = false;
         }
 
+        // Hide devices without model names
+        if (this.device.model === null) {
+            shouldBeVisible = false;
+        } else if (this.device.model.length === 0) {
+            shouldBeVisible = false;
+        }
+
         // Hide system batteries
         if (this.device.kind == UPowerGlib.DeviceKind.BATTERY) {
           shouldBeVisible = false;
@@ -423,12 +430,6 @@ var WirelessHID = GObject.registerClass({
 
             // Add new devices
             for (let i = 0; i < freshDevices.length; i++) {
-                if (freshDevices.model === null) {
-                    continue;
-                } else if (freshDevices[i].model.length === 0) {
-                    continue;
-                }
-
                 let found = false;
                 for (let j in this._devices) {
                     if (this._devices[j].nativePath === freshDevices[i].native_path) {

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -53,7 +53,6 @@ var HID = GObject.registerClass({
         super._init();
 
         this.device = device;
-        this.model = device.model;
         this.nativePath = device.native_path;
         this.icon = null;
         this.item = null;
@@ -237,11 +236,11 @@ var HID = GObject.registerClass({
         }
 
         // Workarounds for incorrectly identified devices
-        if (this.model.includes('Mouse')) {
+        if (this.device.model.includes('Mouse')) {
             iconName = 'input-mouse';
-        } else if (this.model.includes('Controller')) {
+        } else if (this.device.model.includes('Controller')) {
             iconName = 'input-gaming';
-        } else if (this.model.includes('Headset')) {
+        } else if (this.device.model.includes('Headset')) {
             iconName = 'audio-headset';
         }
 
@@ -261,7 +260,7 @@ var HID = GObject.registerClass({
         this.item.remove_child(this.item.label);
 
         let name = new St.Label({
-            text: `${this.model}:`,
+            text: `${this.device.model}:`,
             y_align: Clutter.ActorAlign.CENTER,
             x_align: Clutter.ActorAlign.START
         });

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -117,36 +117,36 @@ var HID = GObject.registerClass({
     _shouldBatteryVisible() {
         let shouldBeVisible = true;
         if (this.device.is_present === false) {
-            shouldBeVisible = false;
+            return false;
         }
 
         // Hide devices without model names
         if (this.device.model === null) {
-            shouldBeVisible = false;
+            return false;
         } else if (this.device.model.length === 0) {
-            shouldBeVisible = false;
+            return false;
         }
 
         // Hide system batteries
         if (this.device.kind == UPowerGlib.DeviceKind.BATTERY) {
-          shouldBeVisible = false;
+          return false;
         }
 
         //Some devices report 'present' as true, even if no battery is present
         //To try work-around this, hide devices with an unknown battery state if enabled
         if (this._settings.get_boolean('hide-unknown-battery-state')) {
             if (this.device.state === UPowerGlib.DeviceState.UNKNOWN) {
-                shouldBeVisible = false;
+                return false;
             }
         }
 
         if (this._settings.get_boolean('hide-elan')) {
             if (this.device.model.startsWith('ELAN')) {
-                shouldBeVisible = false;
+                return false;
             }
         }
 
-        return shouldBeVisible;
+        return true;
     }
 
     _updateLabel() {


### PR DESCRIPTION
Sometimes we get to devices before upower has set a model apparently, to work around them going missing, add them anyway, and ignore them while their model is empty / null. As part of this work, the model is no longer saved explicitly, and is instead directly accessed on the device, as it might change between initialisation and the first time it's shown. The code also now checks the model name every time before it's used, as otherwise we'd just have a crash.

While I was working on that area of the code, I made a minor optimisation to the `shouldBatteryVisible` function, and also fixed the inconsistent spacing before comments.