### PR TITLE
Fix warnings when disabling extension

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -52,5 +52,6 @@ export default class WirelessHIDExtension extends Extension {
 
     disable() {
         this._hid.destroy();
+        this._hid = null;
     }
 }

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -477,11 +477,6 @@ export var WirelessHID = GObject.registerClass({
             this._settingsChangedId = 0;
         }
 
-        if (this._settings) {
-            this._settings.run_dispose();
-            this._settings = null;
-        }
-
         for (let deviceId in this._devices) {
           this._devices[deviceId].destroy();
         }


### PR DESCRIPTION
Fixes warnings when disabling the extension, using the following:
 - `run_dispose()` is discouraged, and unnecessary
 - Setting `this._settings` to `null` before destroying devices might(?) cause problems
   - Either way, it wasn't completely necessary
 - Set `this._hid` to null, to ensure destructors are called on objects and attributes