### PR TITLE
GNOME 46 Porting

### DIFF
--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -6,7 +6,7 @@
     "version": 16,
     "original-author": "chlumskyvaclav@gmail.com",
     "shell-version": [
-      "45"
+      "45", "46"
     ],
     "gettext-domain": "wireless-hid",
     "url": "https://github.com/vchlum/wireless-hid"

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -39,9 +39,12 @@ import GObject from 'gi://GObject';
 import UPowerGlib from 'gi://UPowerGlib';
 import Clutter from 'gi://Clutter';
 
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+
+const ShellVersion = parseFloat(Config.PACKAGE_VERSION);
 
 var HID = GObject.registerClass({
     Signals: {
@@ -326,7 +329,7 @@ export var WirelessHID = GObject.registerClass({
 
     /*
      * WirelessHID class initialization
-     *  
+     *
      * @method _init
      * @private
      */
@@ -485,7 +488,11 @@ export var WirelessHID = GObject.registerClass({
     }
 
     _resetPanelPos() {
-        this.container.get_parent().remove_actor(this.container);
+        if (ShellVersion >= 46) {
+            this.container.get_parent().remove_child(this.container);
+        } else {
+            this.container.get_parent().remove_actor(this.container);
+        }
 
         // Small HACK with private boxes :)
         let boxes = {

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -39,12 +39,9 @@ import GObject from 'gi://GObject';
 import UPowerGlib from 'gi://UPowerGlib';
 import Clutter from 'gi://Clutter';
 
-import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
-
-const ShellVersion = parseFloat(Config.PACKAGE_VERSION);
 
 var HID = GObject.registerClass({
     Signals: {
@@ -489,11 +486,7 @@ export var WirelessHID = GObject.registerClass({
     }
 
     _resetPanelPos() {
-        if (ShellVersion >= 46) {
-            this.container.get_parent().remove_child(this.container);
-        } else {
-            this.container.get_parent().remove_actor(this.container);
-        }
+        this.container.get_parent().remove_child(this.container);
 
         // Small HACK with private boxes :)
         let boxes = {

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -375,16 +375,24 @@ export var WirelessHID = GObject.registerClass({
     newDevice(device) {
         this._devices[device.native_path] = new HID(device, this._settings);
 
-        this._panelBox.add(this._devices[device.native_path].createIcon());
+        if (ShellVersion >= 46) {
+            this._panelBox.add_child(this._devices[device.native_path].createIcon());
+        } else {
+            this._panelBox.add(this._devices[device.native_path].createIcon());
+        }
         this.menu.addMenuItem(this._devices[device.native_path].createItem());
         this._devices[device.native_path].visible = true;
 
         this._devices[device.native_path].connect('show',
             () => {
                 if (!this._devices[device.native_path].visible) {
-                  this._panelBox.add(this._devices[device.native_path].createIcon());
-                  this.menu.addMenuItem(this._devices[device.native_path].createItem());
-                  this._devices[device.native_path].visible = true;
+                    if (ShellVersion >= 46) {
+                        this._panelBox.add_child(this._devices[device.native_path].createIcon());
+                    } else {
+                        this._panelBox.add(this._devices[device.native_path].createIcon());
+                    }
+                    this.menu.addMenuItem(this._devices[device.native_path].createItem());
+                    this._devices[device.native_path].visible = true;
                 }
                 // Uses _update() to avoid cutting timeout short
                 this._devices[device.native_path]._update();
@@ -406,9 +414,9 @@ export var WirelessHID = GObject.registerClass({
         this._devices[device.native_path].connect('destroy',
             () => {
                 if (this._devices[device.native_path].visible) {
-                  this._panelBox.remove_child(this._devices[device.native_path].icon);
-                  this._devices[device.native_path].clean();
-                  this.checkVisibility();
+                    this._panelBox.remove_child(this._devices[device.native_path].icon);
+                    this._devices[device.native_path].clean();
+                    this.checkVisibility();
                 }
             }
         );

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -273,9 +273,9 @@ var HID = GObject.registerClass({
             x_align: Clutter.ActorAlign.START
         });
         name.set_x_expand(true);
-        this.item.add(name);
+        this.item.add_child(name);
 
-        this.item.add(this.createLabel());
+        this.item.add_child(this.createLabel());
 
         return this.item;
     }
@@ -375,22 +375,15 @@ export var WirelessHID = GObject.registerClass({
     newDevice(device) {
         this._devices[device.native_path] = new HID(device, this._settings);
 
-        if (ShellVersion >= 46) {
-            this._panelBox.add_child(this._devices[device.native_path].createIcon());
-        } else {
-            this._panelBox.add(this._devices[device.native_path].createIcon());
-        }
+        this._panelBox.add_child(this._devices[device.native_path].createIcon());
+
         this.menu.addMenuItem(this._devices[device.native_path].createItem());
         this._devices[device.native_path].visible = true;
 
         this._devices[device.native_path].connect('show',
             () => {
                 if (!this._devices[device.native_path].visible) {
-                    if (ShellVersion >= 46) {
-                        this._panelBox.add_child(this._devices[device.native_path].createIcon());
-                    } else {
-                        this._panelBox.add(this._devices[device.native_path].createIcon());
-                    }
+                    this._panelBox.add_child(this._devices[device.native_path].createIcon());
                     this.menu.addMenuItem(this._devices[device.native_path].createItem());
                     this._devices[device.native_path].visible = true;
                 }


### PR DESCRIPTION
The colour changes apparently didn't happen, but `Clutter.Container` was removed, so `add()` and `remove_actor()` needed updating. `add_child()` works on GNOME 45 too, so only `remove_actor()` needed a version-specific work around.

Tested in a VM for GNOME 46 with my Bluetooth card passed through, also tested my regular GNOME 45 desktop, with no issues found on either.

Closes #37