### PR TITLE
Use the warning level from UPower, instead of hardcoding percentages

### DIFF
--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -86,9 +86,9 @@ var HID = GObject.registerClass({
 
     _getColorEffect() {
         let color;
-        if (this.device.percentage <= 5) {
+        if (this.device.warning_level === UPowerGlib.DeviceLevel.CRITICAL) {
             color = Clutter.Color.new(255, 0, 0, 255);
-        } else if (this.device.percentage <= 20) {
+        } else if (this.device.warning_level === UPowerGlib.DeviceLevel.LOW) {
             color = Clutter.Color.new(255, 165, 0, 255);
         } else {
             return null;


### PR DESCRIPTION
Use the warning level from UPower, instead of hardcoded percentages. Otherwise, if the user changes the warning levels from the defaults, GNOME and this extension would fall out of sync.