### PR TITLE
Drop local hacks to override the panel box

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -33,7 +33,6 @@
  * THE SOFTWARE.
  */
 
-import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as WirelessHID from './wirelesshid.js';
 
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
@@ -43,9 +42,8 @@ export default class WirelessHIDExtension extends Extension {
         this._hid = new WirelessHID.WirelessHID(this.metadata.name, this.getSettings());
 
         /* Add indicator to correct position in the panel */
-        Main.panel.addToStatusArea('wireless-hid', this._hid);
+        this._hid.updatePanelPosition();
         this._hid.updateVisibility();
-        this._hid.resetPanelPos();
     }
 
     disable() {

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -320,7 +320,7 @@ export var WirelessHID = GObject.registerClass({
         // Connect to the changed signal
         this._settingsChangedId = this._settings.connect(
             'changed',
-            this.resetPanelPos.bind(this)
+            this.updatePanelPosition.bind(this)
         );
 
         this._upowerClient = UPowerGlib.Client.new_full(null);
@@ -447,19 +447,11 @@ export var WirelessHID = GObject.registerClass({
         Main.panel.statusArea['wireless-hid'].visible = showDevices;
     }
 
-    resetPanelPos() {
-        this.container.get_parent().remove_child(this.container);
-
-        // Small HACK with private boxes :)
-        let boxes = {
-            left: Main.panel._leftBox,
-            center: Main.panel._centerBox,
-            right: Main.panel._rightBox
-        };
-
+    updatePanelPosition() {
+        // Add the container to the correct box
         let position = this._settings.get_string('position-in-panel').toLowerCase();
         let index = this._settings.get_int('panel-box-index');
-        boxes[position].insert_child_at_index(this.container, index);
+        Main.panel.addToStatusArea('wireless-hid', this, index, position);
     }
 
     _onDestroy() {
@@ -472,7 +464,7 @@ export var WirelessHID = GObject.registerClass({
         }
 
         for (let deviceId in this._devices) {
-          this._devices[deviceId].destroy();
+            this._devices[deviceId].destroy();
         }
 
         super._onDestroy();


### PR DESCRIPTION
Upstream now has support for choosing which box to place the indicator in, and will move it if it's already added. Put the `WirelessHid` class in charge of adding itself to the box, and drop our workarounds in favour of the more robust upstream version.

Closes #45