### PR TITLE
Support GNOME 47

### DIFF
--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -6,7 +6,7 @@
     "version": 18,
     "original-author": "chlumskyvaclav@gmail.com",
     "shell-version": [
-      "45", "46"
+      "45", "46", "47"
     ],
     "gettext-domain": "wireless-hid",
     "url": "https://github.com/vchlum/wireless-hid"

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -38,10 +38,14 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import UPowerGlib from 'gi://UPowerGlib';
 import Clutter from 'gi://Clutter';
+import Cogl from 'gi://Cogl';
 
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+
+const ShellVersion = parseFloat(Config.PACKAGE_VERSION);
 
 var HID = GObject.registerClass({
     Signals: {
@@ -87,9 +91,17 @@ var HID = GObject.registerClass({
     _getColorEffect() {
         let color;
         if (this.device.warning_level === UPowerGlib.DeviceLevel.CRITICAL) {
-            color = Clutter.Color.new(255, 0, 0, 255);
+            if (ShellVersion >= 47) {
+                color = Cogl.Color.from_string('#ff0000ff')[1];
+            } else {
+                color = Clutter.Color.new(255, 0, 0, 255);
+            }
         } else if (this.device.warning_level === UPowerGlib.DeviceLevel.LOW) {
-            color = Clutter.Color.new(255, 165, 0, 255);
+            if (ShellVersion >= 47) {
+                color = Cogl.Color.from_string('#ffa500ff')[1];
+            } else {
+                color = Clutter.Color.new(255, 165, 0, 255);
+            }
         } else {
             return null;
         }


### PR DESCRIPTION
 - Add GNOME 47 support to extension metadata
 - Use `Cogl.Color` instead of `Clutter.Color`, since `Clutter.Color` has been removed

~This is untested on both GNOME 46 and GNOME 47, but theoretically it should work on both now. I'll do proper testing soon or closer to GNOME 47's release, but unless anything else changes upstream, hopefully this should be enough :)~

Tested as working on GNOME 46 and GNOME 47