### PR TITLE
Reload entire extension when settings change

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -39,14 +39,26 @@ import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 export default class WirelessHIDExtension extends Extension {
     enable() {
-        this._hid = new WirelessHID.WirelessHID(this.metadata.name, this.getSettings());
+        this._settings = this.getSettings();
+        this._hid = new WirelessHID.WirelessHID(this.metadata.name, this._settings);
 
-        /* Add indicator to correct position in the panel */
+        // Add indicator to correct position in the panel
         this._hid.updatePanelPosition();
         this._hid.updateVisibility();
+
+        // Reload the extension when settings change
+        this._settingsChangedId = this._settings.connect(
+            'changed', () => {
+                this._hid.destroy();
+                this._hid = new WirelessHID.WirelessHID(this.metadata.name, this._settings);
+                this._hid.updatePanelPosition();
+                this._hid.updateVisibility();
+            }
+        );
     }
 
     disable() {
+        this._settings.disconnect(this._settingsChangedId);
         this._hid.destroy();
         this._hid = null;
     }

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -80,12 +80,6 @@ var HID = GObject.registerClass({
             this.refresh.bind(this)
         );
         this._signals[signal] = this.device;
-
-        signal = this._settings.connect(
-            'changed',
-            this.refresh.bind(this)
-        );
-        this._signals[signal] = this._settings;
     }
 
     _getColorEffect() {
@@ -329,11 +323,7 @@ export var WirelessHID = GObject.registerClass({
         // Get saved settings
         this._settings = settings;
 
-        // Connect to the changed signal
-        this._settingsChangedId = this._settings.connect(
-            'changed',
-            this.updatePanelPosition.bind(this)
-        );
+
 
         this._upowerClient = UPowerGlib.Client.new_full(null);
         this._devices = {};
@@ -469,11 +459,6 @@ export var WirelessHID = GObject.registerClass({
     _onDestroy() {
         this._upowerClient.disconnect(this._deviceAddedSignal);
         this._upowerClient.disconnect(this._deviceRemovedSignal);
-
-        if (this._settingsChangedId) {
-            this._settings.disconnect(this._settingsChangedId);
-            this._settingsChangedId = 0;
-        }
 
         for (let deviceId in this._devices) {
             this._devices[deviceId].destroy();


### PR DESCRIPTION
When user settings change, reload the entire extension
 - Fixes the shell complaining the indicator already exists when changing settings
 - Removes the need to reload every device individually and update the panel position when settings change

This might take milliseconds longer than only reloading exactly which parts need to change, but it cuts down on signals and potential bugs, like settings not being applied or shell crashes