### PR TITLE
Add setting to toggle device reported warning levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,16 @@
   - `gnome-shell` (`gnome-extensions` command)
 
 ## Extension settings:
+  > Use device reported warning levels:
+  - Some devices report low battery warnings, others don't
+    - This setting tells the extension to use these for warnings, instead of a percentage
   > Hide unknown battery states:
   - Some devices misreport disconnected batteries as connected
     - To work around this, devices with un unknown battery state can optionally be hidden
     - This is off by default, as it can cause issues and hide some working devices
   > Hide ELAN devices:
   - Some ELAN devices don't report a charge
-    - This setting hides these devices:
+    - This setting hides these devices
   > Hide old devices after a timeout
   - Some devices don't disconnect correctly
     - This setting hides devices that don't update after a length of time

--- a/extension/prefs-adw1.ui
+++ b/extension/prefs-adw1.ui
@@ -19,6 +19,18 @@
         <property name="title" translatable="yes">General settings</property>
         <child>
           <object class="AdwActionRow">
+            <property name="title" translatable="yes">Use device reported warning levels</property>
+            <property name="subtitle" translatable="yes">Use the device reported low battery warnings (not all devices report these)</property>
+            <property name="activatable-widget">use-device-levels-switch</property>
+            <child>
+              <object class="GtkSwitch" id="use-device-levels-switch">
+                <property name="valign">center</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwActionRow">
             <property name="title" translatable="yes">Hide devices with an unknown battery state (may cause issues)</property>
             <property name="subtitle" translatable="yes">Some devices misreport the battery state, this setting attempts to detect and hide these</property>
             <property name="activatable-widget">hide-unknown-states-switch</property>

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -58,6 +58,10 @@ var PrefsPage = class PrefsPage {
         this.preferencesWidget = this._builder.get_object('main-prefs');
 
         this.settingElements = {
+            'use-device-levels-switch': {
+                'settingKey': 'use-device-levels',
+                'bindProperty': 'active'
+            },
             'hide-unknown-states-switch': {
                 'settingKey': 'hide-unknown-battery-state',
                 'bindProperty': 'active'

--- a/extension/schemas/org.gnome.shell.extensions.wireless-hid.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.wireless-hid.gschema.xml
@@ -6,6 +6,11 @@
     <value value="2" nick="Right"/>
   </enum>
   <schema id="org.gnome.shell.extensions.wireless-hid" path="/org/gnome/shell/extensions/wireless-hid/">
+    <key name="use-device-levels" type="b">
+      <default>false</default>
+      <summary>Use device reported warning levels</summary>
+      <description>Use the device reported low battery warnings (not all devices report these)</description>
+    </key>
     <key name="hide-unknown-battery-state" type="b">
       <default>false</default>
       <summary>Hide devices with an unknown battery state (may cause issues)</summary>

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -89,14 +89,31 @@ var HID = GObject.registerClass({
     }
 
     _getColorEffect() {
+        // Decide the level
+        let level = 'normal';
+        if (this._settings.get_boolean('use-device-levels')) {
+            if (this.device.warning_level === UPowerGlib.DeviceLevel.CRITICAL) {
+                level = 'critical';
+            } else if (this.device.warning_level === UPowerGlib.DeviceLevel.LOW) {
+                level = 'low';
+            }
+        } else {
+            if (this.device.percentage <= 5) {
+                level = 'critical';
+            } else if (this.device.percentage <= 20) {
+                level = 'low';
+            }
+        }
+
+        //Decide colour, or return
         let color;
-        if (this.device.warning_level === UPowerGlib.DeviceLevel.CRITICAL) {
+        if (level === 'critical') {
             if (ShellVersion >= 47) {
                 color = Cogl.Color.from_string('#ff0000ff')[1];
             } else {
                 color = Clutter.Color.new(255, 0, 0, 255);
             }
-        } else if (this.device.warning_level === UPowerGlib.DeviceLevel.LOW) {
+        } else if (level === 'low') {
             if (ShellVersion >= 47) {
                 color = Cogl.Color.from_string('#ffa500ff')[1];
             } else {


### PR DESCRIPTION
Some devices don't report warning levels, so default to using percentage-based warning levels
 - Add a setting to enable device reports so those with supported devices can use those reports

Closes #48