### PR TITLE
Null out this._settings when extension is disabled

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -61,5 +61,6 @@ export default class WirelessHIDExtension extends Extension {
         this._settings.disconnect(this._settingsChangedId);
         this._hid.destroy();
         this._hid = null;
+        this._settings = null;
     }
 }


### PR DESCRIPTION
Address the review comments in https://extensions.gnome.org/review/57663

Unfortunately this'll need a new version and another upload @vchlum