### PR TITLE
Add GNOME 48 support

### DIFF
--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -6,7 +6,7 @@
     "version": 20,
     "original-author": "chlumskyvaclav@gmail.com",
     "shell-version": [
-      "45", "46", "47"
+      "45", "46", "47", "48"
     ],
     "gettext-domain": "wireless-hid",
     "url": "https://github.com/vchlum/wireless-hid"


### PR DESCRIPTION
No changes needed, works as is :)

GNOME 48 is currently a beta, so it's not out yet but no more breaking changes are coming