### PR TITLE
Add GNOME 49 support and a setting to highlight charged devices

### DIFF
--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -6,7 +6,7 @@
     "version": 21,
     "original-author": "chlumskyvaclav@gmail.com",
     "shell-version": [
-      "45", "46", "47", "48"
+      "45", "46", "47", "48", "49"
     ],
     "gettext-domain": "wireless-hid",
     "url": "https://github.com/vchlum/wireless-hid"

--- a/extension/prefs-adw1.ui
+++ b/extension/prefs-adw1.ui
@@ -31,6 +31,18 @@
         </child>
         <child>
           <object class="AdwActionRow">
+            <property name="title" translatable="yes">Show fully charged devices in green</property>
+            <property name="subtitle" translatable="yes">Highlight the icons for fully charged devices with green</property>
+            <property name="activatable-widget">highlight-charged-devices-switch</property>
+            <child>
+              <object class="GtkSwitch" id="highlight-charged-devices-switch">
+                <property name="valign">center</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwActionRow">
             <property name="title" translatable="yes">Hide devices with an unknown battery state (may cause issues)</property>
             <property name="subtitle" translatable="yes">Some devices misreport the battery state, this setting attempts to detect and hide these</property>
             <property name="activatable-widget">hide-unknown-states-switch</property>

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -62,6 +62,10 @@ var PrefsPage = class PrefsPage {
                 'settingKey': 'use-device-levels',
                 'bindProperty': 'active'
             },
+            'highlight-charged-devices-switch': {
+                'settingKey': 'highlight-charged-devices',
+                'bindProperty': 'active'
+            },
             'hide-unknown-states-switch': {
                 'settingKey': 'hide-unknown-battery-state',
                 'bindProperty': 'active'

--- a/extension/schemas/org.gnome.shell.extensions.wireless-hid.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.wireless-hid.gschema.xml
@@ -11,6 +11,11 @@
       <summary>Use device reported warning levels</summary>
       <description>Use the device reported low battery warnings (not all devices report these)</description>
     </key>
+    <key name="highlight-charged-devices" type="b">
+      <default>true</default>
+      <summary>Show fully charged devices in green</summary>
+      <description>Highlight the icons for fully charged devices with green</description>
+    </key>
     <key name="hide-unknown-battery-state" type="b">
       <default>false</default>
       <summary>Hide devices with an unknown battery state (may cause issues)</summary>

--- a/extension/wirelesshid.js
+++ b/extension/wirelesshid.js
@@ -99,8 +99,8 @@ var HID = GObject.registerClass({
             }
         }
 
-        //Decide colour, or return
-        let color;
+        // Decide low battery colour
+        let color = null;
         if (level === 'critical') {
             if (ShellVersion >= 47) {
                 color = Cogl.Color.from_string('#ff0000ff')[1];
@@ -113,11 +113,25 @@ var HID = GObject.registerClass({
             } else {
                 color = Clutter.Color.new(255, 165, 0, 255);
             }
+        }
+
+        // Decide fully charged colour
+        if (this._settings.get_boolean('highlight-charged-devices')) {
+          if (this.device.state === UPowerGlib.DeviceState.FULLY_CHARGED) {
+            if (ShellVersion >= 47) {
+                color = Cogl.Color.from_string('#00ff00ff')[1];
+            } else {
+                color = Clutter.Color.new(0, 255, 0, 255);
+            }
+          }
+        }
+
+        // Use the colour if we have one
+        if (color !== null) {
+            return Clutter.ColorizeEffect.new(color);
         } else {
             return null;
         }
-
-        return Clutter.ColorizeEffect.new(color);
     }
 
     _shouldBatteryVisible() {


### PR DESCRIPTION
Completely unrelated changes, but I only had a GNOME 49 Nightly VM available so the GNOME 49 change had to come first.

Adds a new setting that's enabled by default to show fully charged devices in green.

Closes #52 